### PR TITLE
return(invisible(.)), not invisible(return(.))

### DIFF
--- a/R/HTMLcore.R
+++ b/R/HTMLcore.R
@@ -1591,7 +1591,7 @@ NextMethod("HTML")
     attr(x, "orig.call") <- attr(x, "conf.level") <- attr(x, "ordered") <- NULL
 	lapply(unclass(x),HTML,file=file,append=TRUE,...)
     #HTML.default(unclass(x), file=file,...)
-    invisible(return(x))
+    return(invisible(x))
 }
 
 
@@ -3746,7 +3746,7 @@ function(x, HR = 2,CSSclass=NULL,file=HTMLGetFile(), append=TRUE, ...)
     }
     cat("</p>", file = file, append=TRUE, sep = "\n")
     if (substitute(file)=="HTMLGetFile()") try(assign(".HTML.graph", TRUE, envir = .HTMLEnv))
-    invisible(return(TRUE))
+    return(invisible(TRUE))
 }
 
 #----------------------------------------------------------------------------------------------------#
@@ -3756,7 +3756,7 @@ function(x, HR = 2,CSSclass=NULL,file=HTMLGetFile(), append=TRUE, ...)
     cat("\n", file=file, append=append,...)
     cat(paste("<p align=", Align, "><img src='", GraphFileName, "' border=", GraphBorder, if (!is.null(WidthHTML)) paste(" width=",WidthHTML,sep="") else "",if (!is.null(HeightHTML)) paste(" height=",HeightHTML,sep="") else "",">", sep = "", collapse = ""),         file = file, append=TRUE, sep = "")
     if (Caption != "") cat(paste("<br><i class=caption>", Caption, "</i>"), file = file, append=TRUE, sep = "")
-    invisible(return(TRUE))
+    return(invisible(TRUE))
 }
 
 
@@ -3859,7 +3859,7 @@ function(Vec, Replace = " ")
 		}
 	txt <- paste(txt, "</table></td></table></td></table>")
 	cat(txt, "\n", file = file, sep = "", append=TRUE,...)
-	invisible(return(x))
+	return(invisible(x))
 
 	}
 
@@ -3934,13 +3934,13 @@ function(x)
 		}
 
 		if (autobrowse) browseURL(url=get("HTMLtorefresh",envir=.HTMLTmpEnv))
-		invisible(return(TRUE))
+		return(invisible(TRUE))
 		}
 	}
 	on.exit(addTaskCallback(ToHTML(.HTML.file,echo=echo,HTMLframe=HTMLframe,HTMLMenuFile=file.path(outdir,paste(filename,"_menu.",extension,sep="")),target=paste(filename,"_main.",extension,sep=""),outdir=outdir),name="HTML"),add=TRUE)
 	cat("\n *** Output redirected to directory: ", outdir)
 	cat("\n *** Use HTMLStop() to end redirection.")
-	invisible(return(TRUE))
+	return(invisible(TRUE))
 
 }
 #----------------------------------------------------------------------------------------------------#
@@ -4019,7 +4019,7 @@ else	{
 
 }
 
-	invisible(return(file))
+	return(invisible(file))
 }
 
 #----------------------------------------------------------------------------------------------------#
@@ -4042,7 +4042,7 @@ else	{
 	.tmp=get(".HTML.file",envir=.HTMLTmpEnv)
 	HTMLEndFile(file=get(".HTML.file",envir=.HTMLTmpEnv))
 	rm(".HTMLTmpEnv", envir=.HTMLEnv)
-	invisible(return(.tmp))
+	return(invisible(.tmp))
 }
 
 #----------------------------------------------------------------------------------------------------#

--- a/R/grid.R
+++ b/R/grid.R
@@ -140,7 +140,7 @@
 
     cat(paste(txt,collapse="\n"),file=file,append=TRUE)
   if (browse) browseURL(file)
-  invisible(return(file))
+  return(invisible(file))
 }
 
 
@@ -198,7 +198,7 @@
     if (align=="center") txt <- c(txt,"\n</center>")
     cat(paste(txt,collapse="\n"),file=file,append=TRUE)
   if (browse) browseURL(file)
-  invisible(return(file))
+  return(invisible(file))
 }
 ###     HTMLgrid_inline(iris,file=NULL,browse=TRUE)
 


### PR DESCRIPTION
In the latter, invisible() is a no-op because return executes first. Observe:

```
foo = function(x) invisible(return(x))
bar = function(x) return(invisible(x))

foo(5)
# [1] 5
bar(5)
```