### PR TITLE
Add automated check workflow

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,3 @@
 ^\.travis\.yml$
+^\.github/.*
 ^README\.md$

--- a/.github/workflows/package_check.yml
+++ b/.github/workflows/package_check.yml
@@ -1,0 +1,26 @@
+name: R Build and Checks
+on: [push, pull_request]
+
+jobs:
+  R-CMD-check:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          args: 'c("--no-manual", "--as-cran")'
+          error-on: '"note"'
+          check-dir: '"check"'

--- a/.github/workflows/package_check.yml
+++ b/.github/workflows/package_check.yml
@@ -1,5 +1,10 @@
 name: R Build and Checks
-on: [push, pull_request]
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "42 3 21 * *"
 
 jobs:
   R-CMD-check:


### PR DESCRIPTION
Configured to fail on any check "NOTE"s, so the recently reported buglets would have been caught long ago.

Warning level can be adjusted, should it be too strict.

This PR is expected to produce a failed run, initially, until the latest fixes in master are merged into the branch. I'm doing that on purpose, for testing.